### PR TITLE
Fix cat image parameter.

### DIFF
--- a/catterplot/core.py
+++ b/catterplot/core.py
@@ -80,7 +80,7 @@ def catter(x, y, s=40, c=None, cat='random', alpha=1, ax=None, cmap=None,
         cats = np.random.randint(n_cats(), size=len(x))
     else:
         try:
-            cats = np.ones(len(x)) * cat
+            cats = [cat] * len(x)
         except TypeError as e:
             raise TypeError('`cat` argument needs to be "random", a scalar, or match the input.', e)
 


### PR DESCRIPTION
This bug fix will will allow a particular cat image to be chosen. Previously an array of floats were created. Now an array of integers is created, which can correctly be used to index into the array of cat images.

@eteq thank you for making a Python clone of @Gibbsdavidl awesome [catterplots](https://github.com/Gibbsdavidl/CatterPlots) R package.